### PR TITLE
Fix optionnal settings for :channel_status

### DIFF
--- a/lib/cinch/extensions/authentication.rb
+++ b/lib/cinch/extensions/authentication.rb
@@ -53,7 +53,7 @@ module Cinch
       # level - The level Symbol.
       def channel_status_strategy(m, level)
         if config.has_key? :authentication_channel
-          channel = Channel channel[:authentication_channel]
+          channel = Channel config[:authentication_channel]
         elsif bot.config.authentication.channel
           channel = Channel bot.config.authentication.channel
         else


### PR DESCRIPTION
```
[2017/04/27 18:10:07.449] !! [New thread] For #<Cinch::Handler @event=:message pattern=#<Cinch::Pattern:0x000000024b53a0 @prefix=nil, @pattern="test", @suffix=nil>>: #<Thread:0x0000000318f238> -- 1 in total.
[2017/04/27 18:10:07.450] !! /home/sirgue/.gem/ruby/2.4.0/gems/cinch-authentication-0.1.1/lib/cinch/extensions/authentication.rb:56:in `channel_status_strategy': undefined method `[]' for nil:NilClass (NoMethodError)
[2017/04/27 18:10:07.450] !! 	/home/sirgue/.gem/ruby/2.4.0/gems/cinch-authentication-0.1.1/lib/cinch/extensions/authentication.rb:41:in `authenticated?'
[2017/04/27 18:10:07.450] !! 	/usr/lib/ruby/gems/2.4.0/gems/cinch-2.3.3/lib/cinch/plugin.rb:327:in `block in call_hooks'
[2017/04/27 18:10:07.451] !! 	/usr/lib/ruby/gems/2.4.0/gems/cinch-2.3.3/lib/cinch/plugin.rb:322:in `each'
[2017/04/27 18:10:07.451] !! 	/usr/lib/ruby/gems/2.4.0/gems/cinch-2.3.3/lib/cinch/plugin.rb:322:in `find'
[2017/04/27 18:10:07.451] !! 	/usr/lib/ruby/gems/2.4.0/gems/cinch-2.3.3/lib/cinch/plugin.rb:322:in `call_hooks'
[2017/04/27 18:10:07.451] !! 	/usr/lib/ruby/gems/2.4.0/gems/cinch-2.3.3/lib/cinch/plugin.rb:417:in `block (2 levels) in __register_matchers'
[2017/04/27 18:10:07.451] !! 	/usr/lib/ruby/gems/2.4.0/gems/cinch-2.3.3/lib/cinch/handler.rb:99:in `block in call'```